### PR TITLE
ログイン画面の日本語化とレイアウト調整

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,4 +17,10 @@ class ApplicationController < ActionController::Base
   def after_sign_out_path_for(resource_or_scope)
     root_path
   end
+
+  # ログイン後の遷移先をマイページに変更
+  def after_sign_in_path_for(resource)
+    flash[:notice] = "ログインしました。"
+    mypage_path  # トップページ → マイページ に変更
+  end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,44 @@
-<h2>Log in</h2>
-
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+<div class="d-flex justify-content-center align-items-center min-vh-100" style="background-color: #EADDDD;">
+  <div class="signup-box">
+    <div class="text-start mb-5">
+      <%= link_to "← ホームに戻る", root_path, class: "back-button text-decoration-none text-dark" %>
     </div>
-  <% end %>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
+    <div class="logo-title mb-4 text-center">
+      <a class="navbar-brand fw-bold d-flex align-items-center justify-content-center fs-1" href="<%= root_path %>" style="color: #EC69EC;">
+        <%= image_tag 'photomoa_cat.png', alt: 'Photomoa', width: 70, height: 70, class: 'd-inline-block align-text-top me-2' %>
+        Photomoa
+      </a>
+    </div>
+
+    <div class="text-center mb-4">
+      <h2 class="mb-3">おかえりなさい！</h2>
+      <p class="subtitle">あなたの思い出の地図が待っています</p>
+    </div>
+
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="field mb-3">
+        <%= f.label :email, "メールアドレス" %><br />
+        <%= f.email_field :email, autofocus: true, placeholder: "your@email.com", autocomplete: "email", class: "form-control" %>
+      </div>
+
+      <div class="field mb-3">
+        <%= f.label :password, "パスワード" %><br />
+        <%= f.password_field :password, autocomplete: "current-password", placeholder: "パスワードを入力", class: "form-control" %>
+      </div>
+
+      <% if devise_mapping.rememberable? %>
+        <div class="field form-check mb-3">
+          <%= f.check_box :remember_me, class: "form-check-input" %>
+          <%= f.label :remember_me, "ログイン状態を保持する", class: "form-check-label" %>
+        </div>
+      <% end %>
+
+      <div class="actions mb-4">
+        <%= f.submit "ログインする", class: "btn btn-primary w-100" %>
+      </div>
+    <% end %>
+
+    <%= render "devise/shared/links" %>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,30 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end %>
+<div class="d-flex justify-content-center">
+  <div class="text-center">
+    <% if controller_name != 'sessions' %>
+      <%= link_to "ログイン", new_session_path(resource_name), class: "d-block mb-2" %>
+    <% end %>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
+    <% if devise_mapping.registerable? && controller_name != 'registrations' %>
+      <%= link_to "新規登録", new_registration_path(resource_name), class: "d-block mb-2" %>
+    <% end %>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
-<% end %>
+    <% if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+      <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name), class: "d-block mb-2" %>
+    <% end %>
 
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end %>
+    <% if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+      <%= link_to "確認メールを受け取っていませんか？", new_confirmation_path(resource_name), class: "d-block mb-2" %>
+    <% end %>
 
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end %>
+    <% if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+      <%= link_to "アカウントのロック解除メールを受け取っていませんか？", new_unlock_path(resource_name), class: "d-block mb-2" %>
+    <% end %>
 
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
-  <% end %>
-<% end %>
+    <% if devise_mapping.omniauthable? %>
+      <% resource_class.omniauth_providers.each do |provider| %>
+        <%= button_to "#{OmniAuth::Utils.camelize(provider)}でログイン", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "btn btn-outline-primary w-100 mt-2" %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -5,9 +5,11 @@
       Photomoa
     </a>
     <div>
-      <!-- 実際のログインページのパスに変更してください -->
-      <a href="javascript:void(0)" class="btn btn-custom-login">ログイン</a>
-      <!-- 実際の「始める」ページのパスに変更してください -->
+
+      <%= link_to new_user_session_path, class: "btn btn-outline-dark d-inline-flex align-items-center" do %>
+  <i class="bi bi-box-arrow-in-right me-1"></i> ログイン
+<% end %>
+
       <a href="<%= new_user_registration_path %>" class="btn btn-primary" style="background-color: #E256C1; border-color: #E256C1;">始める</a>
     </div>
   </div>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,5 +1,9 @@
 ja:
   devise:
+    shared:
+      links:
+        sign_up: "新規登録"
+        forgot_your_password: "パスワードをお忘れですか？"
     confirmations:
       confirmed: "メールアドレスの確認が完了しました。"
       send_instructions: "確認メールを数分以内に送信します。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,27 +1,21 @@
 Rails.application.routes.draw do
-  get "users/mypage"
+  # Devise routes（ユーザー登録・ログイン関連）
   devise_for :users, controllers: {
-  registrations: "users/registrations"
-}
+    registrations: "users/registrations"
+  }
 
-  resources :posts, only: [ :new, :create, :index ]
+  # 投稿関連
+  resources :posts, only: [:new, :create, :index]
 
-  get "home/top"
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # マイページ用ルート
+  # マイページ（ログイン後のリダイレクト先）
   get "mypage", to: "users#mypage", as: "mypage"
 
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+  # ホーム画面
+  get "home/top"
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  # Health check
+  get "up" => "rails/health#show", as: :rails_health_check
 
-  root "home#top"  # トップページを homeコントローラーの topアクションに設定
+  # トップページ
+  root "home#top"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   }
 
   # 投稿関連
-  resources :posts, only: [:new, :create, :index]
+  resources :posts, only: [ :new, :create, :index ]
 
   # マイページ（ログイン後のリダイレクト先）
   get "mypage", to: "users#mypage", as: "mypage"


### PR DESCRIPTION
ログイン画面を日本語化し、レイアウトを中央寄せにしました。

- deviseのログインフォームのラベル・ボタンを日本語に変更
- リンク（新規登録、パスワード再発行など）も日本語に
- Bootstrapを使ってリンクやフォームを中央に配置
- 不要な英語表示を削除 or 翻訳ファイルに移行